### PR TITLE
Fix getSessionTimeoutInfo sending config in place of data

### DIFF
--- a/packages/platform-shared/src/api/SessionsApi.js
+++ b/packages/platform-shared/src/api/SessionsApi.js
@@ -56,6 +56,7 @@ export function getSessionTimeoutInfo() {
     { params },
   ).post(
     '',
+    null,
     { withCredentials: true },
   );
 }


### PR DESCRIPTION
Fixes issue #23 